### PR TITLE
Add `application/javascript` as a supported mime type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine AS build
 RUN mkdir /code
-RUN apk --no-cache add git build-base
+RUN apk --no-cache add git build-base sed
 WORKDIR /code
 RUN git clone https://git.suckless.org/quark ./
+# Add javascript mime type                                                                                     
+RUN sed -i 's/} mimes\[\] = {/&\n { "js",   "application\/javascript; charset=utf-8" },/' config.def.h                                                                                            
 RUN make
 RUN make install all
 


### PR DESCRIPTION
Thanks for your project. A very handy configuration.
I'm submitting this in the hope that some of your users may find the change helpful.


Very slim web applications consists of .html, .css and .js files.
With no need for a webserver+proxy tandem, quark is the perfect
fit for that type of application.

Good
Quark serves .html and .css files with appropriate `Content-Type` header values.

Bad
For some reason .js files are served with the generic
`application/octet-stream`. The browser refuses to load the .js files
unless they are provided with the appropriate `application/javascript`
content type.

Solution
Just add js->application/javascript mime type as a supported one.